### PR TITLE
Bullet point-ed, added content to Mem&Attn Nets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Please feel free to create [pull requests](https://github.com/keonkim/awesome-nl
 
 ## Table of Contents
 
- - [Tutorials and Courses](#tutorials-and-courses)
-   - [videos](#videos)
+ - [Tutorials](#tutorials)
+   - [Videos and Courses](#videos-and-online-courses)
  - [Deep Learning for NLP](#deep-learning-for-nlp)
  - [Packages](#packages)
    - [Implemendations](#implementations)
@@ -232,6 +232,7 @@ Tai et al. 2015  Introduces Tree LSTM. Uses a parse tree.
 [Semi-supervised Sequence Learning](http://arxiv.org/pdf/1511.01432.pdf)
 Dai, Le 2015 "With pretraining, we are able to train long short term memory recurrent networks up to a few hundred
 timesteps, thereby achieving strong performance in many text classification tasks, such as IMDB, DBpedia and 20 Newsgroups."
+
 ### Machine Translation
 [Neural Machine Translation by jointly learning to align and translate](http://arxiv.org/pdf/1409.0473v6.pdf)
 Bahdanau, Cho 2014.  "comparable to the existing state-of-the-art phrase-based system on the task of English-to-French translation."  Implements attention mechanism.
@@ -258,23 +259,21 @@ Shang et al. 2015  Uses Neural Responding Machine.  Trained on Weibo dataset.  A
 [A Neural Conversation Model](http://arxiv.org/pdf/1506.05869v3.pdf)
 Vinyals, [Le](https://scholar.google.com/citations?user=vfT6-XIAAAAJ) 2015.  Uses LSTM RNNs to generate conversational responses. Uses [seq2seq framework](http://tensorflow.org/tutorials/seq2seq/index.html).  Seq2Seq was originally designed for machine transation and it "translates" a single sentence, up to around 79 words, to a single sentence response, and has no memory of previous dialog exchanges.  Used in Google [Smart Reply feature for Inbox](http://googleresearch.blogspot.co.uk/2015/11/computer-respond-to-this-email.html)
 
-### Memory and Attention Models (from [DL4NLP](https://github.com/andrewt3000/DL4NLP))
-[Reasoning, Attention and Memory RAM workshop at NIPS 2015. slides included](http://www.thespermwhale.com/jaseweston/ram/)
-
-[Memory Networks](http://arxiv.org/pdf/1410.3916v10.pdf) Weston et. al 2014, and
-[End-To-End Memory Networks](http://arxiv.org/pdf/1503.08895v4.pdf) Sukhbaatar et. al 2015.
-Memory networks are implemented in [MemNN](https://github.com/facebook/MemNN).  Attempts to solve task of reason attention and memory.
-[Towards AI-Complete Question Answering: A Set of Prerequisite Toy Tasks](http://arxiv.org/pdf/1502.05698v7.pdf)
-Weston 2015. Classifies QA tasks like single factoid, yes/no etc. Extends memory networks.
-[Evaluating prerequisite qualities for learning end to end dialog systems](http://arxiv.org/pdf/1511.06931.pdf)
-Dodge et. al 2015. Tests Memory Networks on 4 tasks including reddit dialog task.
-See [Jason Weston lecture on MemNN](https://www.youtube.com/watch?v=Xumy3Yjq4zk)
-
-[Neural Turing Machines](http://arxiv.org/pdf/1410.5401v2.pdf)
-Graves et al. 2014.
-
-[Inferring Algorithmic Patterns with Stack-Augmented Recurrent Nets](http://arxiv.org/pdf/1503.01007v4.pdf)
-Joulin, Mikolov 2015. [Stack RNN source code](https://github.com/facebook/Stack-RNN) and [blog post](https://research.facebook.com/blog/1642778845966521/inferring-algorithmic-patterns-with-stack/)
+### Memory and Attention Models 
+Most are courtesy [andrewt3000/DL4NLP](https://github.com/andrewt3000/DL4NLP)
+* [Augmented RNNs](www.distill.pub/2016/augmented-rnns/) is an amazing interactive Tutorial on Attention and Memory networks
+* [Reasoning, Attention and Memory RAM workshop at NIPS 2015. slides included](http://www.thespermwhale.com/jaseweston/ram/)
+* [Memory Networks](http://arxiv.org/pdf/1410.3916v10.pdf) Weston et. al 2014
+* [End-To-End Memory Networks](http://arxiv.org/pdf/1503.08895v4.pdf) Sukhbaatar et. al 2015
+Memory networks are implemented in [MemNN](https://github.com/facebook/MemNN).  Attempts to solve task of reason attention and memory
+* [Towards AI-Complete Question Answering: A Set of Prerequisite Toy Tasks](http://arxiv.org/pdf/1502.05698v7.pdf)
+Weston 2015. Classifies QA tasks like single factoid, yes/no etc. Extends memory networks
+* [Evaluating prerequisite qualities for learning end to end dialog systems](http://arxiv.org/pdf/1511.06931.pdf)
+Dodge et. al 2015. Tests Memory Networks on 4 tasks including reddit dialog task
+* [Jason Weston lecture on MemNN](https://www.youtube.com/watch?v=Xumy3Yjq4zk)
+* [Neural Turing Machines](http://arxiv.org/pdf/1410.5401v2.pdf), Graves et al. 2014
+* [Inferring Algorithmic Patterns with Stack-Augmented Recurrent Nets](http://arxiv.org/pdf/1503.01007v4.pdf), Joulin, Mikolov 2015 
+* [Stack RNN source code](https://github.com/facebook/Stack-RNN) and [blog post](https://research.facebook.com/blog/1642778845966521/inferring-algorithmic-patterns-with-stack/)
 
 ### General Natural Language Processing
 * [Neural autocoder for paragraphs and documents](http://arxiv.org/abs/1506.01057) - LSTM representation


### PR DESCRIPTION
1. Fixed internal hyperlinks in ToC
2. Added Augmented RNN in Memory and Attention Networks
3. Converted M&A Networks section from free flow to bullet points for readability