### PR TITLE
Add NLP Architect to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Bayesian, statistics and Linguistics approaches for Natural Language Processing 
   - [Chazutsu](https://github.com/chakki-works/chazutsu) - A library for downloading&parsing standard NLP research datasets
   - [Word Forms](https://github.com/gutfeeling/word_forms) - Word forms can accurately generate all possible forms of an English word
   - [Multilingual Latent Dirichlet Allocation (LDA)](https://github.com/ArtificiAI/Multilingual-Latent-Dirichlet-Allocation-LDA) - A multilingual and extensible document clustering pipeline
+  - [NLP Architect](https://github.com/NervanaSystems/nlp-architect) - A library for exploring the state-of-the-art deep learning topologies and techniques for NLP and NLU
 
 - <a id="c++">**C++** - C++ Libraries</a> | [Back to Top](#contents)
   - [MIT Information Extraction Toolkit](https://github.com/mit-nlp/MITIE) - C, C++, and Python tools for named entity recognition and relation extraction


### PR DESCRIPTION
Hi,

I'd like to suggest adding NLP Architect open source library.
NLP Architect is a python based NLP and NLU research framework exploring deep learning based models. It contains 15 models ranging from basic NLP task up to more complex and novel NLU models and is in active development by Intel AI.

More details on the library can be found [here](https://github.com/NervanaSystems/nlp-architect) and [here](http://nlp_architect.nervanasys.com/).

Thanks