### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/README-ZH-TW.md
+++ b/README-ZH-TW.md
@@ -310,7 +310,7 @@ _請在提交之前閱讀 [貢獻指南](contributing.md) 。請隨時創建 [�
 - [KoNLPy](http://konlpy.org) - 用於韓語自然語言處理的Python包。
 - [Mecab (Korean)](https://eunjeon.blogspot.com/) - 韓文的自然語言處理 C++ 函式庫
 - [KoalaNLP](https://koalanlp.github.io/koalanlp/) - 韓國自然語言處理的 Scala 函式庫。
-- [KoNLP](https://cran.r-project.org/web/packages/KoNLP/index.html) - 韓文的自然語言處理 R 包。
+- [KoNLP](https://cran.r-project.org/package=KoNLP) - 韓文的自然語言處理 R 包。
 
 ### 部落格與教學
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ NLP as API with higher level functionality such as NER, Topic tagging and so on 
 - [KoNLPy](http://konlpy.org) - Python package for Korean natural language processing.
 - [Mecab (Korean)](https://eunjeon.blogspot.com/) - C++ library for Korean NLP
 - [KoalaNLP](https://koalanlp.github.io/koalanlp/) - Scala library for Korean Natural Language Processing.
-- [KoNLP](https://cran.r-project.org/web/packages/KoNLP/index.html) - R package for Korean Natural language processing
+- [KoNLP](https://cran.r-project.org/package=KoNLP) - R package for Korean Natural language processing
 
 ### Blogs and Tutorials
 


### PR DESCRIPTION
[CRAN asks to use the `package=` URL variant](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.