### PR TITLE
Proposing addition of rust-bert

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Blogs and Newsletters
 - <a id="rust">**Rust**</a>
   - [whatlang](https://github.com/greyblake/whatlang-rs) — Natural language recognition library based on trigrams
   - [snips-nlu-rs](https://github.com/snipsco/snips-nlu-rs) - A production ready library for intent parsing
+  - [rust-bert](https://github.com/guillaume-be/rust-bert) - Ready-to-use NLP pipelines and Transformer-based models
 
 ### Services
 


### PR DESCRIPTION
Sharing a port of Transformers library (https://github.com/guillaume-be/rust-bert) to Rust. It includes ready to use NLP pipelines (sentiment analysis, NER, question answering, text generation) and implementation of common transformer architectures (BERT, DistilBERT, RoBERTa, GPT, GPT2) in Rust.