### PR TITLE
Adding Spark NLP library

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Blogs and Newsletters
   - [tm](https://github.com/ispras/tm) - Implementation of topic modeling based on regularized multilingual [PLSA](https://en.wikipedia.org/wiki/Probabilistic_latent_semantic_analysis).
   - [word2vec-scala](https://github.com/Refefer/word2vec-scala) - Scala interface to word2vec model; includes operations on vectors like word-distance and word-analogy.
   - [Epic](https://github.com/dlwh/epic) - Epic is a high performance statistical parser written in Scala, along with a framework for building complex structured prediction models.
+  - [Spark NLP](https://github.com/JohnSnowLabs/spark-nlp) - Spark NLP is a natural language processing library built on top of Apache Spark ML that provides simple, performant & accurate NLP annotations for machine learning pipelines that scale easily in a distributed environment.
 
 - <a id="R">**R** - R NLP Libraries</a> | [Back to Top](#contents)
   - [text2vec](https://github.com/dselivanov/text2vec) - Fast vectorization, topic modeling, distances and GloVe word embeddings in R.


### PR DESCRIPTION
Thanks for adding the Spark NLP library to the list. I put it in the Scala section since it is written in Scala, but it does support Java, Python, and R.

Many thanks.