### PR TITLE
Add PySS3 to Python's Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Blogs and Newsletters
   - [PyTorch-NLP](https://github.com/PetrochukM/PyTorch-NLP) - NLP research toolkit designed to support rapid prototyping with better data loaders, word vector loaders, neural network layer representations, common NLP metrics such as BLEU
   - [Rosetta](https://github.com/columbia-applied-data-science/rosetta) - Text processing tools and wrappers (e.g. Vowpal Wabbit)
   - [PyNLPl](https://github.com/proycon/pynlpl) - Python Natural Language Processing Library. General purpose NLP library for Python. Also contains some specific modules for parsing common NLP formats, most notably for [FoLiA](https://proycon.github.io/folia/), but also ARPA language models, Moses phrasetables, GIZA++ alignments.
+  - [PySS3](https://github.com/sergioburdisso/pyss3) - Python package that implements a novel white-box machine learning model for text classification, called SS3. Since SS3 has the ability to visually explain its rationale, this package also comes with easy-to-use interactive visualizations tools ([online demos](http://tworld.io/ss3/)).
   - [jPTDP](https://github.com/datquocnguyen/jPTDP) - A toolkit for joint part-of-speech (POS) tagging and dependency parsing. jPTDP provides pre-trained models for 40+ languages.
   - [BigARTM](https://github.com/bigartm/bigartm) - a fast library for topic modelling
   - [Snips NLU](https://github.com/snipsco/snips-nlu) - A production ready library for intent parsing


### PR DESCRIPTION
PySS3 is an open-source python package that implements a novel white-box machine learning model (SS3) for text classification. In addition, PySS3 comes with a set of visualizations tools for Explainable Artificial Intelligence (XAI).

Github repo: [https://github.com/sergioburdisso/pyss3](https://github.com/sergioburdisso/pyss3)
Online live demos: [http://tworld.io/ss3/](http://tworld.io/ss3/)
Documentation: [https://pyss3.readthedocs.io](https://pyss3.readthedocs.io)
Paper preprint: [https://arxiv.org/abs/1912.09322](https://arxiv.org/abs/1912.09322)

---

Since we've put a lot of work on this project, I know that my opinion could be really really skewed, but I believe that maybe PySS3 deserves a shot... if you have time, check it out... I hope you find it worthy of being on this list, that is, I hope you find it ![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg) enough :/

Have a nice day! :)

**PS:** PySS3 has already been added to the [Awesome  Machine Learning](https://github.com/josephmisiti/awesome-machine-learning) list. However, it would be great if it could also be added here since this list is "NLP-specific", and PySS3 is used for (interpretable/explainable) text classification.