### PR TITLE
ADD new library for NLP in Spanish

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ NLP as API with higher level functionality such as NER, Topic tagging and so on 
 
 [Back to Top](#contents)
 
+### Libraries
+
+- [spanlp](https://github.com/jfreddypuentes/spanlp) - Python library to detect, censor and clean profanity, vulgarities, hateful words, racism, xenophobia and bullying in texts written in Spanish. It contains data of 21 Spanish-speaking countries.
+
 ### Data
 
 - [Columbian Political Speeches](https://github.com/dav009/LatinamericanTextResources)


### PR DESCRIPTION
I add python library for nlp in spanish section.
**spanlp**: nlp applied for spanish vulgarity. A fast, robust Python library to check for profanity or offensive language in Spanish strings. It contains all the rude words of Spanish-speaking countries.