### PR TITLE
Add the dl-translate Python library

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ Material can be found [here](https://github.com/aws-samples/aws-machine-learning
   - [Transformers](https://github.com/huggingface/transformers) - Natural Language Processing for TensorFlow 2.0 and PyTorch.
   - [Tokenizers](https://github.com/huggingface/tokenizers) - Tokenizers optimized for Research and Production.
   - [fairSeq](https://github.com/pytorch/fairseq) Facebook AI Research implementations of SOTA seq2seq models in Pytorch. 
-  - [corex_topic](https://github.com/gregversteeg/corex_topic) - Hierarchical Topic Modeling with Minimal Domain Knowledge  
+  - [corex_topic](https://github.com/gregversteeg/corex_topic) - Hierarchical Topic Modeling with Minimal Domain Knowledge
+  - [DL Translate](https://github.com/xhlulu/dl-translate) - A deep learning-based translation library for 50 languages, built on `transformers` and Facebook's mBART Large.
 
 - <a id="c++">**C++** - C++ Libraries</a> | [Back to Top](#contents)
   - [MIT Information Extraction Toolkit](https://github.com/mit-nlp/MITIE) - C, C++, and Python tools for named entity recognition and relation extraction


### PR DESCRIPTION
DL Translate is a deep learning-based translation library built on Huggingface transformers and Facebook's mBART-Large. It works for 50 different languages.

Pasted below is a preview of the Readme:

> 💻 [GitHub Repository](https://github.com/xhlulu/dl-translate)<br>
> 📚 [Documentation](https://git.io/dlt-docs) / [Readthedocs](https://dl-translate.readthedocs.io)<br>
> 🐍 [PyPi project](https://pypi.org/project/dl-translate/)<br>
> 🧪 [Colab Demo](https://colab.research.google.com/github/xhlulu/dl-translate/blob/main/demos/colab_demo.ipynb) / [Kaggle Demo](https://www.kaggle.com/xhlulu/dl-translate-demo/)
> 
> 
> ## Quickstart
> 
> Install the library with pip:
> ```
> pip install dl-translate
> ```
> 
> To translate some text:
> 
> ```python
> import dl_translate as dlt
> 
> mt = dlt.TranslationModel()  # Slow when you load it for the first time
> 
> text_hi = "संयुक्त राष्ट्र के प्रमुख का कहना है कि सीरिया में कोई सैन्य समाधान नहीं है"
> mt.translate(text_hi, source=dlt.lang.HINDI, target=dlt.lang.ENGLISH)
> ```
> 
> Above, you can see that `dlt.lang` contains variables representing each of the 50 available languages with auto-complete support. Alternatively, you can specify the language (e.g. "Arabic") or the language code (e.g. "fr_XX" for French):
> ```python
> text_ar = "الأمين العام للأمم المتحدة يقول إنه لا يوجد حل عسكري في سوريا."
> mt.translate(text_ar, source="Arabic", target="fr_XX")
> ```
> 
> If you want to verify whether a language is available, you can check it:
> ```python
> print(mt.available_languages())  # All languages that you can use
> print(mt.available_codes())  # Code corresponding to each language accepted
> print(mt.get_lang_code_map())  # Dictionary of lang -> code