### PR TITLE
add more portuguese materials (nlportugues & Brasileiras em PLN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,8 @@ NLP as API with higher level functionality such as NER, Topic tagging and so on 
 [Back to Top](#contents)
 
 - [Portuguese-nlp](https://github.com/ajdavidl/Portuguese-NLP) - a List of resources and tools developed with focus on Portuguese.
+- [NLPortuguês](https://nlportugues.ime.usp.br/) - NLP course in brazilian portuguese
+- [Brasileiras em PLN](https://brasileiraspln.com/livro-pln/1a-edicao/) - NLP book in brazilian portugues
 
 ## Other Languages
 


### PR DESCRIPTION
there are not that many nlp reference materials written in the Portuguese language, so I added a book and a course both about NLP in (brazilian) Portuguese. These materials were developed by the University of Sao Paulo (NLPortugues) and brazilian nlp researchers from many universities (Brasileiras em PLN)

Since many portuguese speaking programmers also use this repo, I believe this would be a nice addition.

> # Contribution Guidelines
> 
> Please ensure your pull request adheres to the following guidelines:
> - Use the following format: [Bookmark Title](link): Description.
> 

should I edit the whole Portuguese section to follow this? When I made the commit I just followed what was already there