### PR TITLE
Add PraisonAI to Python NLP Libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Material can be found [here](https://github.com/aws-samples/aws-machine-learning
   - [Kashgari](https://github.com/BrikerMan/Kashgari) - Simple, Keras-powered multilingual NLP framework, allows you to build your models in 5 minutes for named entity recognition (NER), part-of-speech tagging (PoS) and text classification tasks. Includes BERT and word2vec embedding.
   - [FARM](https://github.com/deepset-ai/FARM) - Fast & easy transfer learning for NLP. Harvesting language models for the industry. Focus on Question Answering.
   - [Haystack](https://github.com/deepset-ai/haystack) - End-to-end Python framework for building natural language search interfaces to data. Leverages Transformers and the State-of-the-Art of NLP. Supports DPR, Elasticsearch, HuggingFace’s Modelhub, and much more!
+  - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - Multi-AI Agents framework with 100+ LLM support via LiteLLM, MCP integration, agentic workflows, and built-in memory for NLP tasks.
   - [Rita DSL](https://github.com/zaibacu/rita-dsl) - a DSL, loosely based on [RUTA on Apache UIMA](https://uima.apache.org/ruta.html). Allows to define language patterns (rule-based NLP) which are then translated into [spaCy](https://spacy.io/), or if you prefer less features and lightweight - regex patterns.
   - [Transformers](https://github.com/huggingface/transformers) - Natural Language Processing for TensorFlow 2.0 and PyTorch.
   - [Tokenizers](https://github.com/huggingface/tokenizers) - Tokenizers optimized for Research and Production.


### PR DESCRIPTION
## Adding PraisonAI

[PraisonAI](https://github.com/MervinPraison/PraisonAI) is a Multi-AI Agents framework suitable for NLP tasks.

### Key Features:
- **100+ LLM support** via LiteLLM (OpenAI, Anthropic, Gemini, Ollama, Groq, etc.)
- **MCP Protocol support** for seamless tool integration
- **Agentic workflows** with route(), parallel(), loop(), repeat() patterns
- **Built-in memory** (short-term, long-term, entity, episodic)
- **Self-reflection** for improved agent responses
- **Python & JavaScript SDKs**

### NLP Use Cases:
- Text classification and summarization
- Named entity recognition
- Question answering
- Document analysis
- Multi-agent NLP pipelines

### Quick Start:
```python
from praisonaiagents import Agent

agent = Agent(instructions="You are an NLP expert")
agent.start("Analyze the sentiment of this text")
```

- **GitHub**: https://github.com/MervinPraison/PraisonAI
- **Documentation**: https://docs.praison.ai

Thank you!