### PR TITLE
Add "The Math Behind Artificial Intelligence" book to Books section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Material can be found [here](https://github.com/aws-samples/aws-machine-learning
 * [Real-World Natural Language Processing](https://www.manning.com/books/real-world-natural-language-processing) - by Masato Hagiwara
 * [Natural Language Processing in Action, Second Edition](https://www.manning.com/books/natural-language-processing-in-action-second-edition) - by Hobson Lane and Maria Dyshel
 * [Transformers in Action](https://www.manning.com/books/transformers-in-action) - by Nicole Koenigstein
+* [The Math Behind Artificial Intelligence](https://www.freecodecamp.org/news/the-math-behind-artificial-intelligence-book) - bt Tiago MOnteiro | A free FreeCodeCamp book teaching the math behind AI in plain English from an engineering point of view. It covers linear algebra, calculus, probability & statistics, and optimization theory with analogies, real-life applications, and Python code examples.
   
 ## Libraries
 


### PR DESCRIPTION
Added a mathematical foundations resource to the Books section under Tutorials.

**Resource:** The Math Behind Artificial Intelligence by Tiago Monteiro (freeCodeCamp, 2026)
Link: https://www.freecodecamp.org/news/the-math-behind-artificial-intelligence-book

**Why this is useful:** This free book provides the mathematical underpinnings essential for understanding modern NLP techniques like word embeddings, transformers, and neural language models. It covers:
- linear algebra (matrix operations used in attention mechanisms)
- calculus (backpropagation)
- probability & statistics (language modeling)
- optimization theory (gradient descent)

The engineering-focused approach with visual explanations and Python examples complements existing NLP books.

**Placement:** Added to the bottom of the Books section under Tutorials, following the contribution guidelines.