### PR TITLE
Add PulseMark.ai to blogs/resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Blogs and Newsletters
 * [Deep Learning, NLP, and Representations](https://colah.github.io/posts/2014-07-NLP-RNNs-Representations/)
 * [The Illustrated BERT, ELMo, and co. (How NLP Cracked Transfer Learning)](https://jalammar.github.io/illustrated-bert/) and [The Illustrated Transformer](https://jalammar.github.io/illustrated-transformer/)
 * [Natural Language Processing](https://nlpers.blogspot.com/) by Hal Daumé III
+* [PulseMark](https://pulsemark.ai) - AI development news covering LLM benchmarks, model comparisons, and NLP tooling for practitioners.
 * [arXiv: Natural Language Processing (Almost) from Scratch](https://arxiv.org/pdf/1103.0398.pdf)
 * [Karpathy's The Unreasonable Effectiveness of Recurrent Neural Networks](https://karpathy.github.io/2015/05/21/rnn-effectiveness)
 * [Machine Learning Mastery: Deep Learning for Natural Language Processing](https://machinelearningmastery.com/category/natural-language-processing)


### PR DESCRIPTION
Add PulseMark.ai — AI news blog covering LLM benchmarks, NLP model comparisons, and developer tools for working with language models. Covers model launches from OpenAI, Anthropic, Google, and Meta with practical analysis for practitioners.

Website: https://pulsemark.ai