### PR TITLE
Add kreuzberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Material can be found [here](https://github.com/aws-samples/aws-machine-learning
   - [whatlang](https://github.com/greyblake/whatlang-rs) — Natural language recognition library based on trigrams
   - [snips-nlu-rs](https://github.com/snipsco/snips-nlu-rs) - A production ready library for intent parsing
   - [rust-bert](https://github.com/guillaume-be/rust-bert) - Ready-to-use NLP pipelines and Transformer-based models
+  - [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) - Polyglot document intelligence library that extracts text, tables, and metadata from 62+ formats for NLP preprocessing, with bindings for Python, TypeScript, Ruby, Go, Java, C#, PHP, and Elixir
 
 - <a id="NLP++">**NLP++** - NLP++ Language</a> | [Back to Top](#contents)
   - [VSCode Language Extension](https://marketplace.visualstudio.com/items?itemName=dehilster.nlp) - NLP++ Language Extension for VSCode


### PR DESCRIPTION
Adds [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) to the Rust libraries section.

Kreuzberg is a polyglot document intelligence library with a Rust core and bindings for Python, TypeScript, Ruby, Go, Java, C#, PHP, and Elixir. It extracts text, tables, and metadata from 62+ document formats, making it useful for NLP preprocessing pipelines.