### PR TITLE
Add AI Displacement Tracker to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ NLP as API with higher level functionality such as NER, Topic tagging and so on 
 - [nlp-datasets](https://github.com/niderhoff/nlp-datasets) great collection of nlp datasets
 - [gensim-data](https://github.com/RaRe-Technologies/gensim-data) - Data repository for pretrained NLP models and NLP corpora.
 - [tiny_qa_benchmark_pp](https://github.com/vincentkoc/tiny_qa_benchmark_pp/) - Repository of tiny NLP multi-lingual QA datasets and library to generate your own synthetic copies.
+- [ai-displacement-tracker](https://github.com/noahaust2/ai-displacement-tracker) - Structured dataset of 94 AI-attributed workforce displacement events (453K+ workers, 12 countries). Useful for NLP tasks like named entity recognition, event extraction, and information extraction from corporate communications.
 
 ## Multilingual NLP Frameworks
 


### PR DESCRIPTION
Adds [AI Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) to the Datasets section.

**What it is:** A structured dataset of 94 AI-attributed workforce displacement events (453K+ workers, 12 countries, 11 sectors). CSV/JSON with company names, dates, countries, worker counts, and source URLs.

**NLP relevance:** The dataset's structured text fields (company names, sector classifications, job function categories, source URLs to news articles and corporate announcements) are useful for NLP tasks including named entity recognition, event extraction, and information extraction from corporate communications.

Listed in [awesome-datascience](https://github.com/academic/awesome-datascience) (24K stars).