### PR TITLE
Add AI Displacement Tracker to Datasets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ NLP as API with higher level functionality such as NER, Topic tagging and so on 
 - [nlp-datasets](https://github.com/niderhoff/nlp-datasets) great collection of nlp datasets
 - [gensim-data](https://github.com/RaRe-Technologies/gensim-data) - Data repository for pretrained NLP models and NLP corpora.
 - [tiny_qa_benchmark_pp](https://github.com/vincentkoc/tiny_qa_benchmark_pp/) - Repository of tiny NLP multi-lingual QA datasets and library to generate your own synthetic copies.
+- [AI Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) - Structured dataset of 121 AI-attributed workforce displacement events across 15 countries (496,000+ workers). Firm-level data on how NLP/AI adoption affects employment.
 
 ## Multilingual NLP Frameworks
 


### PR DESCRIPTION
## Add AI Displacement Tracker dataset

Adds the [AI Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) to the Datasets section.

**What it is:** A structured, source-verified dataset tracking 121 AI-attributed workforce displacement events across 15 countries (496,000+ workers affected). Each event includes company name, date, workers affected, sector, job functions, attribution tier (confirmed/probable), evidence summary, and source URLs.

**Why it fits Datasets:** This dataset documents the real-world labor market impact of NLP/AI deployment. It provides empirical evidence researchers need to study the societal effects of the technologies cataloged in this list.

**Data quality:** CC-BY-4.0 licensed. Available in JSON and CSV formats. Each event is individually sourced.