### PR TITLE
Add widemem-ai — open-source AI memory layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Material can be found [here](https://github.com/aws-samples/aws-machine-learning
   - [Jury](https://github.com/obss/jury) - Evaluation of NLP model outputs offering various automated metrics.
   - [python-ucto](https://github.com/proycon/python-ucto) - Unicode-aware regular-expression based tokenizer for various languages. Python binding to C++ library, supports [FoLiA format](https://proycon.github.io/folia).
   - [Pearmut](https://github.com/zouharvi/pearmut) - Human annotation tool for multilingual NLP tasks, such as machine translation.
+  - [widemem-ai](https://github.com/remete618/widemem-ai) - Open-source AI memory layer with importance scoring, temporal decay, hierarchical memory, and YMYL prioritization.
 
 - <a id="c++">**C++** - C++ Libraries</a> | [Back to Top](#contents)
   - [InsNet](https://github.com/chncwang/InsNet) - A neural network library for building instance-dependent NLP models with padding-free dynamic batching.


### PR DESCRIPTION
Adding [widemem-ai](https://github.com/remete618/widemem-ai) — open-source AI memory layer with importance scoring, temporal decay, hierarchical memory, and YMYL prioritization.

- Website: https://widemem.ai
- License: Apache 2.0