### PR TITLE
Add FinSignals to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ NLP as API with higher level functionality such as NER, Topic tagging and so on 
 - [Textalytic](https://www.textalytic.com) - Natural Language Processing in the Browser with sentiment analysis, named entity extraction, POS tagging, word frequencies, topic modeling, word clouds, and more
 - [NLP Cloud](https://nlpcloud.io) - SpaCy NLP models (custom and pre-trained ones) served through a RESTful API for named entity recognition (NER), POS tagging, and more.
 - [Cloudmersive](https://cloudmersive.com/nlp-api) - Unified and free NLP APIs that perform actions such as speech tagging, text rephrasing, language translation/detection, and sentence parsing
+- [FinSignals](https://finsignals.ai) - Reddit-tuned financial NLP API returning 7 classification heads per post (sentiment, directionality, quality, post type, relevance score, author confidence, sarcasm) in a single synchronous call. Built for trading pipelines. Free tier available.
 
 ### Annotation Tools
 


### PR DESCRIPTION
Adds [FinSignals](https://finsignals.ai) - a Reddit-tuned financial NLP API that returns 7 classification heads per post (sentiment, directionality, quality, post type, relevance score, author confidence, sarcasm) in a single synchronous call.

Unlike general-purpose NLP services, FinSignals is trained specifically on Reddit finance communities and understands financial slang, meme language, and sarcasm. Built for trading pipelines. Free tier available.