### PR TITLE
Add AI Weekly to newsletter/resource list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 * [Highlights of EMNLP 2017: Exciting Datasets, Return of the Clusters, and More!](http://blog.aylien.com/highlights-emnlp-2017-exciting-datasets-return-clusters/)
 * [Deep Learning for Natural Language Processing (NLP): Advancements & Trends](https://tryolabs.com/blog/2017/12/12/deep-learning-for-nlp-advancements-and-trends-in-2017/?utm_campaign=Revue%20newsletter&utm_medium=Newsletter&utm_source=The%20Wild%20Week%20in%20AI)
 * [Survey of the State of the Art in Natural Language Generation](https://arxiv.org/abs/1703.09902)
+- [AI Weekly](https://aiweekly.co) - Curated AI intelligence briefing from industry leaders covering models, funding, policy, and applications. 3x/week since 2017, 40K+ subscribers.
 
 ## Prominent NLP Research Labs
 [Back to Top](#contents)


### PR DESCRIPTION
Adding [AI Weekly](https://aiweekly.co) — curated AI intelligence briefing from industry leaders. 3x/week since 2017, 40K+ subscribers covering models, funding, policy, and real-world applications.

Featured on Machine Learning Mastery and multiple 'best AI newsletters' roundups.