### PR TITLE
Add Not Human Search to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ NLP as API with higher level functionality such as NER, Topic tagging and so on 
 - [Textalytic](https://www.textalytic.com) - Natural Language Processing in the Browser with sentiment analysis, named entity extraction, POS tagging, word frequencies, topic modeling, word clouds, and more
 - [NLP Cloud](https://nlpcloud.io) - SpaCy NLP models (custom and pre-trained ones) served through a RESTful API for named entity recognition (NER), POS tagging, and more.
 - [Cloudmersive](https://cloudmersive.com/nlp-api) - Unified and free NLP APIs that perform actions such as speech tagging, text rephrasing, language translation/detection, and sentence parsing
+- [Not Human Search](https://nothumansearch.ai) - Search engine and MCP server for discovering agent-ready NLP and AI tools, with a REST API and agentic readiness scoring based on llms.txt, OpenAPI, and MCP support
 
 ### Annotation Tools
 


### PR DESCRIPTION
## Summary

- Adds [Not Human Search](https://nothumansearch.ai) to the **Services** section
- Not Human Search is a search engine and MCP server that indexes 1,100+ agent-ready AI and NLP tools
- Provides a REST API for programmatic discovery and scores tools 0-100 based on agentic readiness (llms.txt, OpenAPI, MCP support)
- Listed in the official MCP registry

## Why this belongs here

The Services section lists "NLP as API with higher level functionality." Not Human Search provides a REST API and MCP server specifically for discovering NLP and AI tools programmatically, making it directly relevant to NLP practitioners building agent-based workflows.

## Checklist

- [x] Individual pull request for a single suggestion
- [x] Added to the bottom of the relevant category (Services)
- [x] Follows existing link format
- [x] Spelling and grammar checked