### PR TITLE
Add Not Human Search to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ NLP as API with higher level functionality such as NER, Topic tagging and so on 
 - [Textalytic](https://www.textalytic.com) - Natural Language Processing in the Browser with sentiment analysis, named entity extraction, POS tagging, word frequencies, topic modeling, word clouds, and more
 - [NLP Cloud](https://nlpcloud.io) - SpaCy NLP models (custom and pre-trained ones) served through a RESTful API for named entity recognition (NER), POS tagging, and more.
 - [Cloudmersive](https://cloudmersive.com/nlp-api) - Unified and free NLP APIs that perform actions such as speech tagging, text rephrasing, language translation/detection, and sentence parsing
+- [Not Human Search](https://nothumansearch.ai/) - AI tool discovery engine with agentic scoring. REST API and MCP server for searching and evaluating AI tools programmatically.
 
 ### Annotation Tools
 


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai/) to the Services section.

Not Human Search is an AI tool discovery engine with agentic scoring. It provides a REST API and MCP server for searching and evaluating 8,600+ AI tools programmatically.

- Website: https://nothumansearch.ai
- API: https://nothumansearch.ai/api/v1/search?q=nlp
- Docs: https://nothumansearch.ai/llms.txt