### PR TITLE
Add Korean RAG SSOT Golden 50 dataset to NLP in Korean Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ NLP as API with higher level functionality such as NER, Topic tagging and so on 
 - [Petitions](https://github.com/akngs/petitions) - Collect expired petition data from the Blue House National Petition Site.
 - [Korean Parallel corpora](https://github.com/j-min/korean-parallel-corpora) - Neural Machine Translation(NMT) Dataset for **Korean to French** & **Korean to English**
 - [KorQuAD](https://korquad.github.io/) - Korean SQuAD dataset with Wiki HTML source. Mentions both v1.0 and v2.1 at the time of adding to Awesome NLP
+- [Korean RAG SSOT Golden 50](https://huggingface.co/datasets/neogenesislab/korean-rag-ssot-golden-50) - Bilingual ko/en RAG retrieval golden set of 50 tasks across 5 categories (rag design, quant, governance, security/PII, ops) with 5 evaluation metrics including credential-leak-rate and injection-quarantine-recall.
 
 ## NLP in Arabic
 


### PR DESCRIPTION
## What this adds

Adds [Korean RAG SSOT Golden 50](https://huggingface.co/datasets/neogenesislab/korean-rag-ssot-golden-50) to the **NLP in Korean > Datasets** section.

## Why it's useful

A bilingual ko/en RAG retrieval golden set covering 50 hand-curated tasks across 5 categories (rag design, quant, governance, security/PII, ops). Includes 5 evaluation metrics with primary `recall_at_10` >= 0.85 target, plus security-focused metrics rare in Korean retrieval datasets: `credential_leak_rate` (target 0.0) and `injection_quarantine_recall` (target 0.95). Useful for RAG eval and Korean retrieval research.

- License: CC-BY-4.0
- Format: Loadable via `datasets.load_dataset()`
- Use cases: RAG retrieval baselines, Korean PII/credential redaction eval, prompt-injection regression testing