### PR TITLE
Add Dakera to Retrieval and Embeddings — self-hosted hybrid search memory for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,10 @@ Embedding and retrieval benchmarks:
 
 - [MMTEB](https://arxiv.org/abs/2502.13595) (2025) - community expansion of MTEB to 500+ tasks across 250+ languages.
 
+Retrieval infrastructure and memory servers:
+
+- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted retrieval memory server for AI agents, combining BM25 full-text search with HNSW vector indexing. MCP-native protocol, persistent RocksDB storage, supports hybrid search across long-horizon agent conversations.
+
 ### Speech and Text
 
 [Back to Top](#contents)


### PR DESCRIPTION
## What

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Tasks and Methods > Retrieval and Embeddings** section, under a new "Retrieval infrastructure and memory servers" subsection.

## Why it fits

Dakera is a self-hosted retrieval memory server purpose-built for AI agents. It combines BM25 full-text search with HNSW vector indexing for hybrid retrieval — exactly the kind of infrastructure that powers modern RAG and long-context agent workflows. The server exposes a standard MCP interface and persists all data to RocksDB, making it deployable without any external service dependencies.

Relevant to the NLP community because:
- Hybrid BM25 + vector retrieval is a core NLP infrastructure pattern
- Enables long-horizon agent memory by indexing and retrieving conversation history
- Fully self-hosted, open source — no vendor retrieval API required
- MCP protocol standardizes how language model agents access persistent knowledge

## Entry added

In `### Retrieval and Embeddings`, under a new prose header "Retrieval infrastructure and memory servers":

```
- [Dakera](https://github.com/dakera-ai/dakera-mcp) - Self-hosted retrieval memory server for AI agents, combining BM25 full-text search with HNSW vector indexing. MCP-native protocol, persistent RocksDB storage, supports hybrid search across long-horizon agent conversations.
```