### PR TITLE
Add FakeShield AI — NLP-based fake news detector with explainability

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,8 @@ LLM-based:
 - [PySS3](https://github.com/sergioburdisso/pyss3) - white-box, interpretable text classifier.
 - [LLMs as Annotators](https://arxiv.org/abs/2305.13734) - using LLMs for text classification labeling, with caveats.
 
+- [FakeShield AI](https://github.com/aasimansari1/fake-news-detector) - Flask web app for fake news detection using TF-IDF + NLP pipeline; compares Passive Aggressive, Naive Bayes, Logistic Regression and Random Forest models (~91% accuracy); returns confidence score and per-word influence direction.
+
 ### Topic Modeling
 
 [Back to Top](#contents)


### PR DESCRIPTION
## Addition: Text Classification section

**[FakeShield AI](https://github.com/aasimansari1/fake-news-detector)** — An open-source Flask web application for fake news detection. Uses a full NLP pipeline (lowercasing → tokenisation → stopword removal → lemmatisation → TF-IDF with bigrams) and benchmarks 4 classifiers (Passive Aggressive, Naive Bayes, Logistic Regression, Random Forest), automatically selecting the best-performing one (~91% accuracy on the Kaggle Fake News dataset).

Key features relevant to this list:
- Explainable predictions: returns key words with per-word influence direction (fake vs real)
- REST API (`POST /predict`) returning confidence score + probability breakdown
- Fully open source, MIT licensed
- Compatible with any CSV dataset with `text` + `label` columns