### PR TITLE
Add FunASR to Speech and Text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ A short pointer set, since this borders adjacent fields:
 - [Whisper](https://github.com/openai/whisper) - multilingual ASR; the modern open default.
 - [SeamlessM4T](https://github.com/facebookresearch/seamless_communication) - unified speech and text translation.
 - [Canary](https://huggingface.co/nvidia/canary-1b) (NVIDIA, 2024) - top open multilingual ASR model.
+- [FunASR](https://github.com/modelscope/FunASR) - industrial-grade ASR toolkit; 170× realtime on GPU, 50+ languages, built-in VAD, punctuation, speaker diarization, and emotion detection. Includes non-autoregressive SenseVoice and LLM-based Fun-ASR-Nano models.
 - [Wav2Vec 2.0](https://arxiv.org/abs/2006.11477) - foundational self-supervised speech pretraining.
 - [Coqui TTS](https://github.com/coqui-ai/TTS) and [VieNeu-TTS](https://github.com/pnnbao97/VieNeu-TTS) - open TTS.
 


### PR DESCRIPTION
Adds [FunASR](https://github.com/modelscope/FunASR) to the **Speech and Text** section.

FunASR is an industrial-grade ASR toolkit with 16K+ GitHub stars and 1M+ monthly pip installs. Key features:

- **170× realtime** on GPU, 17× on CPU
- **50+ languages** with built-in VAD, punctuation restoration, speaker diarization, and emotion detection
- Includes non-autoregressive **SenseVoice** (234M params, ultra-fast) and LLM-based **Fun-ASR-Nano** (800M params, 31 languages)
- OpenAI-compatible API server (`/v1/audio/transcriptions`)
- Production-ready: used in 40+ open-source integrations including GPT-SoVITS, Dify, and Pipecat

Already listed in [awesome-python](https://github.com/vinta/awesome-python) and [awesome-production-machine-learning](https://github.com/EthicalML/awesome-production-machine-learning).