### PR TITLE
Add SEACrowd to NLP in Indonesian datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,7 @@ Resources organized by human language. Click a section to expand.
 - [Indonesian Treebank](https://github.com/famrashel/idn-treebank) and [Universal Dependencies-Indonesian](https://github.com/UniversalDependencies/UD_Indonesian-GSD)
 - [IndoSum](https://github.com/kata-ai/indosum) - text summarization and classification.
 - [Wordnet-Bahasa](http://wn-msa.sourceforge.net/) - large, free, semantic dictionary.
+- [SEACrowd](https://github.com/SEACrowd/seacrowd-datahub) - A multilingual and multimodal data hub providing standardized datasets and benchmarks for Southeast Asian NLP (EMNLP 2024).
 
 </details>
 


### PR DESCRIPTION
This PR adds SEACrowd to the NLP in Indonesian datasets section.

SEACrowd is an open-source multilingual and multimodal data hub providing standardized Hugging Face dataloaders and benchmarks for Southeast Asian NLP, covering text, image, and audio modalities across multiple languages including Indonesian.

Reference: Lovenia et al. (EMNLP 2024) https://doi.org/10.18653/v1/2024.emnlp-main.296