### PR TITLE
Add Building Speech AI resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Material can be found [here](https://github.com/aws-samples/aws-machine-learning
 * [Real-World Natural Language Processing](https://www.manning.com/books/real-world-natural-language-processing) - by Masato Hagiwara
 * [Natural Language Processing in Action, Second Edition](https://www.manning.com/books/natural-language-processing-in-action-second-edition) - by Hobson Lane and Maria Dyshel
 * [Transformers in Action](https://www.manning.com/books/transformers-in-action) - by Nicole Koenigstein
+* [Building Speech AI: A Practitioner's Guide](https://prdeepakbabu.github.io/building-speech-ai) - by Deepak Babu Piskala. Covers speech representation, ASR, neural TTS, self-supervised speech models, and audio language models with companion code.
 * [The Math Behind Artificial Intelligence](https://www.freecodecamp.org/news/the-math-behind-artificial-intelligence-book) - bt Tiago MOnteiro | A free FreeCodeCamp book teaching the math behind AI in plain English from an engineering point of view. It covers linear algebra, calculus, probability & statistics, and optimization theory with analogies, real-life applications, and Python code examples.
   
 ## Libraries


### PR DESCRIPTION
Adds Building Speech AI: A Practitioner's Guide to the Books section. The book covers speech representation, ASR, neural TTS, self-supervised speech models, and audio language models with companion code, which fits the speech and NLP overlap in this list.