### PR TITLE
Add Garu (browser-native Korean morphological analyzer) to NLP in Korean

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,7 @@ Resources organized by human language. Click a section to expand.
 - [KoNLP](https://cran.r-project.org/package=KoNLP) - R package for Korean NLP.
 - [kss](https://github.com/hyunwoongko/kss) - Korean sentence splitter.
 - [Kiwi](https://github.com/bab2min/Kiwi) - fast Korean morphological analyzer.
+- [Garu](https://github.com/ongjin/garu) - browser-native Korean morphological analyzer running fully client-side via WebAssembly (1MB model, offline, MIT).
 
 ### Models and Embeddings
 


### PR DESCRIPTION
Adds **Garu** to the *NLP in Korean* section.

The Korean analyzers currently listed (KoNLPy, Mecab, Kiwi, …) all assume a server or native runtime. Garu fills that gap: it runs full morphological analysis **entirely in the browser via WebAssembly**, with a 1 MB model bundled in the npm package — no server, works offline.

- Repo: https://github.com/ongjin/garu
- npm: https://www.npmjs.com/package/garu-ko
- Live demo: https://garu.zerry.co.kr
- MIT · Sejong POS tagset · deterministic (no neural net) · F1 93.6% on a 9k-sentence gold set

Disclosure: I'm the author of Garu.