### PR TITLE
Add SOAS English-Uzbek RAG Evaluation dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,10 +1313,6 @@ Resources organized by human language. Click a section to expand.
 
 - [SOAS English-Uzbek RAG Evaluation](https://github.com/rajantripathi/soas-rag-evaluation) - Bilingual retrieval-evaluation benchmark for culturally grounded RAG. 400 rows, EN+UZ, MIT/CC-BY-4.0.
 
-### Applications
-
-- [AUT Chatbot](https://github.com/rajantripathi/autchatbot-) - Local RAG chatbot for aut-edu.uz FAQs using Ollama. Handles Uzbek, Russian, and English. MIT.
-
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This list covers natural language processing — linguistic analysis, multilingu
   * [NLP in Thai](#nlp-in-thai)
   * [NLP in Ukrainian](#nlp-in-ukrainian)
   * [NLP in Urdu](#nlp-in-urdu)
+  * [NLP in Uzbek](#nlp-in-uzbek)
   * [NLP in Vietnamese](#nlp-in-vietnamese)
   * [Other Languages](#other-languages)
 * [See Also](#see-also)
@@ -1296,6 +1297,25 @@ Resources organized by human language. Click a section to expand.
 ### Datasets
 
 - [Collection of Urdu datasets](https://github.com/mirfan899/Urdu) - POS, NER, and other NLP tasks.
+
+</details>
+
+<details>
+<summary>
+
+### NLP in Uzbek
+
+</summary>
+
+[Back to Top](#contents)
+
+### Datasets
+
+- [SOAS English-Uzbek RAG Evaluation](https://github.com/rajantripathi/soas-rag-evaluation) - Bilingual retrieval-evaluation benchmark for culturally grounded RAG. 400 rows, EN+UZ, MIT/CC-BY-4.0.
+
+### Applications
+
+- [AUT Chatbot](https://github.com/rajantripathi/autchatbot-) - Local RAG chatbot for aut-edu.uz FAQs using Ollama. Handles Uzbek, Russian, and English. MIT.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds a new `NLP in Uzbek` subsection with SOAS English-Uzbek RAG Evaluation, a bilingual retrieval-evaluation dataset for culturally grounded RAG.

## Why this fits

The contribution is scoped to multilingual NLP and retrieval evaluation. Uzbek is currently absent from the language-specific sections, and the entry adds low-resource Central Asian NLP coverage without adding a general chatbot or RAG starter-kit application.

## Notes

The linked repository includes a 400-row retrieval-evaluation dataset and documentation under MIT/CC-BY-4.0 licensing.