### PR TITLE
Add SenseBench, an English word sense disambiguation benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,7 @@ Modern LM evaluation (2023-2026):
 - [MMLU](https://github.com/hendrycks/test) - multitask knowledge evaluation across 57 subjects.
 - [MMLU-Pro](https://arxiv.org/abs/2406.01574) (2024) - harder, more discriminative successor to MMLU.
 - [GPQA](https://arxiv.org/abs/2311.12022) - graduate-level Q&A, "Google-proof" reasoning evaluation.
+- [SenseBench](https://sense-bench.com) (2026) - English word sense disambiguation benchmark: models pick the correct WordNet 3.0 sense for a word in context, over the lexicographer-reviewed [lexEN](https://github.com/GliteTech/lexen) set; runs re-verified from stored raw API responses.
 - [REFUTE](https://huggingface.co/datasets/BGPT-OFFICIAL/refute) (2026) - scientific reasoning benchmark for evidence-grounded critique, overclaim detection, missing-evidence refusal, and calibration.
 - [IFEval](https://arxiv.org/abs/2311.07911) - verifiable instruction-following evaluation.
 - [Chatbot Arena (LMSYS)](https://lmarena.ai/) - human-preference ELO leaderboard for chat models.


### PR DESCRIPTION
Adds one line to **Language Models for NLP → Evaluation and Benchmarks → Modern LM evaluation (2023-2026)**, beside MMLU, GPQA, REFUTE and LiveBench.

```markdown
- [SenseBench](https://sense-bench.com) (2026) - English word sense disambiguation benchmark: models pick the correct WordNet 3.0 sense for a word in context, over the lexicographer-reviewed [lexEN](https://github.com/GliteTech/lexen) set; runs re-verified from stored raw API responses.
```

### Why it is useful

The list has no word sense disambiguation resource. WSD is one of the oldest tasks in NLP, and it has become interesting again for a reason that fits this section: the labels rather than the models are now the bottleneck. Frontier systems sit close enough together that residual annotation error decides the ranking.

The dataset it runs on, lexEN, is the scientific contribution rather than the leaderboard. It takes the standard [Raganato et al. 2017](http://lcl.uniroma1.it/wsdeval/) all-words framework as corrected by [Maru et al. 2022](https://github.com/SapienzaNLP/wsd-hard-benchmark) and adds a further round of manual review: a model panel flagged 363 contested items, three professional lexicographers reviewed them independently — blind to the source label, to which system flagged the item, and to one another's answers — and a two-of-three majority rule fixed before adjudication decided each case. 211 labels changed, 56 items were removed as unanswerable, 4,861 remain.

The review record is published rather than summarised: per-item annotator choices, inter-annotator agreement (Fleiss κ 0.537 at fine WordNet granularity, 0.740 under coarser sense grouping), the reviewer brief, and the complete item-level diff against the source labels. That κ figure is itself a result — three professional lexicographers agreeing only moderately at fine granularity suggests a share of reported WSD system error is disagreement about the sense inventory rather than about the word.

Data is CC BY-NC 4.0, inherited from Maru et al. 2022; the harness is Apache-2.0 and on PyPI as `sensebench`.

### Guidelines checklist

- [x] Individual pull request for a single suggestion
- [x] Format `[Relevant Link](link)`
- [x] Added to the bottom of the relevant category
- [x] Spelling and grammar checked; no trailing whitespace introduced
