### PR TITLE
Add yasbd-lib to Python NLP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Material can be found [here](https://github.com/aws-samples/aws-machine-learning
   - [sacrebleu](https://github.com/mjpost/sacrebleu) - reproducible BLEU/chrF/TER scoring for machine translation.
   - [COMET](https://github.com/Unbabel/COMET) - learned MT metrics, current de-facto standard.
   - [LangTest](https://github.com/JohnSnowLabs/langtest) - 60+ test types for NLP model robustness, bias, and fairness.
+   - [yasbd-lib](https://github.com/speedyk-005/yasbd-lib) - High-accuracy, rule-based sentence boundary detector (SBD). Drop-in pysbd adapter, streaming APIs, CLI, and a spaCy component across 39+ languages.
 
 - <a id="c++">**C++** - C++ Libraries</a> | [Back to Top](#contents)
   - [InsNet](https://github.com/chncwang/InsNet) - A neural network library for building instance-dependent NLP models with padding-free dynamic batching.


### PR DESCRIPTION
## What does this PR do?

Adds **[yasbd-lib](https://github.com/speedyk-005/yasbd-lib)** (**Y**et **A**nother **S**entence **B**oundary **D**etector) to the **Python** NLP section of the README.

A high-accuracy, rule-based sentence boundary detector (SBD) for Python that handles abbreviations, initials, decimals, ellipses, and multilingual punctuation without naive split-on-punctuation failures. 

## Checklist

- [x] Searched previous suggestions (no duplicate)
- [x] Added to the bottom of the relevant category (Python)
- [x] Used the `[Bookmark Title](link): Description` format
- [x] Description is 1–2 sentences, required
- [x] No trailing whitespace

Closes #415
